### PR TITLE
Compute inventory totalQuantity from packSize, increase quantity precision, and format UI quantities

### DIFF
--- a/src/app/[locale]/admin/dashboard/page.tsx
+++ b/src/app/[locale]/admin/dashboard/page.tsx
@@ -58,6 +58,13 @@ const STATUS_BADGE: Record<string, { bg: string; text: string; dot: string }> =
     empty: { bg: "bg-red-50", text: "text-red-700", dot: "bg-red-500" },
   };
 
+function formatQuantity(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
 export default function DashboardPage() {
   const locale = useLocale();
   const t = useTranslations("admin.dashboard");
@@ -244,7 +251,8 @@ export default function DashboardPage() {
                   </span>
                 </div>
                 <span className="text-sm font-cabin text-elite-black/50">
-                  {a.totalQty} {isAr ? a.unitAr : a.unit}
+                  {formatQuantity(a.totalQty, locale)}{" "}
+                  {isAr ? a.unitAr : a.unit}
                 </span>
               </div>
             ))}
@@ -333,13 +341,16 @@ export default function DashboardPage() {
                       {isAr ? level.nameAr : level.name}
                     </td>
                     <td className="text-center px-3 py-2.5 text-elite-black/50 hidden min-[480px]:table-cell">
-                      {level.storageQty}
+                      {formatQuantity(level.storageQty, locale)}{" "}
+                      {isAr ? level.unitAr : level.unit}
                     </td>
                     <td className="text-center px-3 py-2.5 text-elite-black/50 hidden min-[480px]:table-cell">
-                      {level.barQty}
+                      {formatQuantity(level.barQty, locale)}{" "}
+                      {isAr ? level.unitAr : level.unit}
                     </td>
                     <td className="text-center px-3 py-2.5 font-medium text-elite-black">
-                      {level.totalQty}
+                      {formatQuantity(level.totalQty, locale)}{" "}
+                      {isAr ? level.unitAr : level.unit}
                     </td>
                     <td className="text-center px-3 py-2.5">
                       <span className="inline-flex items-center justify-center">

--- a/src/app/[locale]/admin/inventory/storage/page.tsx
+++ b/src/app/[locale]/admin/inventory/storage/page.tsx
@@ -72,7 +72,7 @@ export default function StorageCountPage() {
 
   const step = useCallback(
     (itemId: string, delta: number, itemUnit: string) => {
-      const inc = itemUnit === "kg" || itemUnit === "liter" ? 0.5 : 1;
+      const inc = itemUnit === "kg" || itemUnit === "liter" ? 0.1 : 1;
       setEntries((prev) => ({
         ...prev,
         [itemId]: Math.max(0, (prev[itemId] ?? 0) + delta * inc),

--- a/src/app/[locale]/admin/inventory/transfer/page.tsx
+++ b/src/app/[locale]/admin/inventory/transfer/page.tsx
@@ -210,7 +210,7 @@ export default function TransferPage() {
                       Math.max(
                         0,
                         q -
-                          (unitUsed === "kg" || unitUsed === "liter" ? 0.5 : 1),
+                          (unitUsed === "kg" || unitUsed === "liter" ? 0.1 : 1),
                       ),
                     )
                   }
@@ -232,7 +232,7 @@ export default function TransferPage() {
                     setQuantity(
                       (q) =>
                         q +
-                        (unitUsed === "kg" || unitUsed === "liter" ? 0.5 : 1),
+                        (unitUsed === "kg" || unitUsed === "liter" ? 0.1 : 1),
                     )
                   }
                   className="w-12 h-12 rounded-2xl bg-elite-cream/60 border border-elite-burgundy/15 text-elite-burgundy text-xl font-medium flex items-center justify-center hover:bg-elite-cream transition-colors"

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -22,6 +22,17 @@ const createCountSchema = z.object({
   submit: z.boolean().default(false),
 });
 
+type ParsedEntry = z.infer<typeof entrySchema>;
+
+function calculateTotalQuantity(
+  entry: ParsedEntry,
+  item: { packSize: number },
+): number {
+  if (entry.quantity > 0) return entry.quantity;
+  const packSize = item.packSize > 0 ? item.packSize : 1;
+  return entry.packsCount * packSize + entry.looseSingles;
+}
+
 export async function GET(req: NextRequest) {
   try {
     const user = await requireRole(req, [
@@ -122,6 +133,36 @@ export async function POST(req: NextRequest) {
       wasteNotes,
       submit,
     } = parsed.data;
+
+    const itemIds = Array.from(new Set(entries.map((entry) => entry.itemId)));
+    const inventoryItems = await prisma.inventoryItem.findMany({
+      where: { id: { in: itemIds } },
+      select: { id: true, packSize: true },
+    });
+    const itemById = new Map(inventoryItems.map((item) => [item.id, item]));
+
+    if (inventoryItems.length !== itemIds.length) {
+      return NextResponse.json(
+        { success: false, error: "One or more items were not found" },
+        { status: 404 },
+      );
+    }
+
+    const normalizedEntries = entries.map((entry) => {
+      const item = itemById.get(entry.itemId);
+      if (!item) {
+        throw new Error(`Missing inventory item ${entry.itemId}`);
+      }
+
+      return {
+        itemId: entry.itemId,
+        packsCount: entry.packsCount,
+        looseSingles: entry.looseSingles,
+        quantity: entry.quantity,
+        totalQuantity: calculateTotalQuantity(entry, item),
+      };
+    });
+
     const today = new Date(new Date().toISOString().split("T")[0]);
 
     const existingDraft = await prisma.inventoryCount.findFirst({
@@ -149,18 +190,7 @@ export async function POST(req: NextRequest) {
           status: submit ? "submitted" : "draft",
           submittedAt: submit ? new Date() : null,
           entries: {
-            create: entries.map((e) => {
-              const item = {
-                itemId: e.itemId,
-                packsCount: e.packsCount,
-                looseSingles: e.looseSingles,
-                quantity: e.quantity,
-                totalQuantity: 0,
-              };
-              item.totalQuantity =
-                e.quantity || e.packsCount * 50 + e.looseSingles;
-              return item;
-            }),
+            create: normalizedEntries,
           },
         },
         include: { entries: true },
@@ -201,13 +231,7 @@ export async function POST(req: NextRequest) {
         shortageNotes,
         wasteNotes,
         entries: {
-          create: entries.map((e) => ({
-            itemId: e.itemId,
-            packsCount: e.packsCount,
-            looseSingles: e.looseSingles,
-            quantity: e.quantity,
-            totalQuantity: e.quantity || e.packsCount * 50 + e.looseSingles,
-          })),
+          create: normalizedEntries,
         },
       },
       include: { entries: true },

--- a/tests/integration/api/adminInventoryAPI.test.ts
+++ b/tests/integration/api/adminInventoryAPI.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/admin/inventory/route";
+import { prismaMock } from "@/tests/setup/prisma";
+
+vi.mock("@/server/auth/session", () => ({
+  requireRole: vi.fn().mockResolvedValue({ id: "user-1" }),
+}));
+
+describe("API Integrations: Admin Inventory POST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calculates totalQuantity using each item's packSize", async () => {
+    prismaMock.inventoryItem.findMany.mockResolvedValue([
+      { id: "11111111-1111-4111-8111-111111111111", packSize: 24 },
+      { id: "22222222-2222-4222-8222-222222222222", packSize: 12 },
+    ] as never);
+    prismaMock.inventoryCount.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    prismaMock.inventoryCount.create.mockResolvedValue({
+      id: "count-1",
+      entries: [],
+    } as never);
+
+    const req = new NextRequest("http://localhost/api/admin/inventory", {
+      method: "POST",
+      body: JSON.stringify({
+        location: "bar",
+        shiftConfirmed: "morning",
+        entries: [
+          {
+            itemId: "11111111-1111-4111-8111-111111111111",
+            packsCount: 2,
+            looseSingles: 3,
+            quantity: 0,
+          },
+          {
+            itemId: "22222222-2222-4222-8222-222222222222",
+            packsCount: 4,
+            looseSingles: 1,
+            quantity: 0.75,
+          },
+        ],
+        submit: true,
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(prismaMock.inventoryCount.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.inventoryCount.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          entries: {
+            create: expect.arrayContaining([
+              expect.objectContaining({
+                itemId: "11111111-1111-4111-8111-111111111111",
+                totalQuantity: 51,
+              }),
+              expect.objectContaining({
+                itemId: "22222222-2222-4222-8222-222222222222",
+                totalQuantity: 0.75,
+              }),
+            ]),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("returns 404 when submitted item ids do not match inventory records", async () => {
+    prismaMock.inventoryItem.findMany.mockResolvedValue([
+      { id: "11111111-1111-4111-8111-111111111111", packSize: 24 },
+    ] as never);
+
+    const req = new NextRequest("http://localhost/api/admin/inventory", {
+      method: "POST",
+      body: JSON.stringify({
+        location: "bar",
+        shiftConfirmed: "morning",
+        entries: [
+          {
+            itemId: "11111111-1111-4111-8111-111111111111",
+            quantity: 1,
+          },
+          {
+            itemId: "33333333-3333-4333-8333-333333333333",
+            quantity: 1,
+          },
+        ],
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.success).toBe(false);
+    expect(prismaMock.inventoryCount.create).not.toHaveBeenCalled();
+    expect(prismaMock.inventoryCount.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure inventory counts store accurate `totalQuantity` by using each item's `packSize` and loose singles instead of a hardcoded pack size.
- Improve quantity precision for weight/volume units and make displayed numbers respect the current `locale`.

### Description
- Add server-side normalization that fetches `inventoryItem` records for submitted `itemId`s, validates presence, and computes `totalQuantity` using a new `calculateTotalQuantity` helper that uses `packsCount`, `packSize`, and `looseSingles` (or `quantity` when provided).  
- Replace in-place hardcoded pack-size math with `normalizedEntries` and persist those entries on both create and update flows in the `POST /api/admin/inventory` handler.  
- Increase precision for `kg`/`liter` increments/steps from `0.5` to `0.1` in the storage count and transfer pages by changing the step/stepper logic.  
- Add client-side `formatQuantity` to format displayed quantities with `Intl.NumberFormat(locale)` and apply it across the dashboard list and table cells.  
- Add typed helper `ParsedEntry` and small error handling to return `404` when submitted item ids do not match existing inventory records.

### Testing
- Added integration tests in `tests/integration/api/adminInventoryAPI.test.ts` and ran them with `vitest`; both tests completed and passed.  
- Tests verify that `totalQuantity` is computed from each item's `packSize` and that the API returns `404` when an unknown `itemId` is submitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee117c1ea083288e78c879e8d0dc3a)