### PR TITLE
fix: deep investigation fixes for menu catalog consistency

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -26,6 +26,12 @@ const EXCLUDED_CATEGORIES = [
   "Toppings", // Add-ons (handled as product attributes)
   "Sauces", // Add-ons (handled as product attributes)
   "Elite Essentials", // Internal supplies
+  "other", // Catch-all for uncategorized items that shouldn't be shown
+  "Uncategorized", // Odoo default category for uncategorized products
+  "Miscellaneous", // Common catch-all category that may contain non-menu items
+  "Internal", // Internal use only items
+  "Supplies", // Non-menu items used for operations
+  "POS Only", // Items meant exclusively for point-of-sale, not online
 ];
 
 export async function GET(_request: NextRequest) {

--- a/src/server/services/product.service.ts
+++ b/src/server/services/product.service.ts
@@ -38,10 +38,36 @@ export type Category = {
 const SOFT_TTL = 30 * 60 * 1000;
 const HARD_TTL = 2 * 60 * 60; // seconds for Redis
 
+// Categories that must never appear in any website-facing endpoint.
+// Keep in sync with the same list in api/categories/route.ts and api/products/route.ts.
+const EXCLUDED_CATEGORY_NAMES = new Set([
+  "Extras",
+  "EXTRA",
+  "Services",
+  "Offers",
+  "Expenses",
+  "Toppings",
+  "Sauces",
+  "Elite Essentials",
+  "other",
+  "Uncategorized",
+  "Miscellaneous",
+  "Internal",
+  "Supplies",
+  "POS Only",
+]);
+
 // Product names that should never be exposed in website catalog endpoints.
-const EXCLUDED_PRODUCT_NAME_PATTERNS = [/^open\s*register$/i];
+const EXCLUDED_PRODUCT_NAME_PATTERNS = [
+  /^open\s*register$/i,
+  /^open\s*cashier$/i,
+];
 
 function isExcludedWebsiteProduct(product: Product): boolean {
+  // Exclude by category
+  if (!product.category) return true; // no category = not a menu item
+  if (EXCLUDED_CATEGORY_NAMES.has(product.category.name)) return true;
+  // Exclude known POS-admin product names regardless of category
   const name = product.name?.trim();
   if (!name) return false;
   return EXCLUDED_PRODUCT_NAME_PATTERNS.some((pattern) => pattern.test(name));

--- a/src/server/utils/oldItemsMapping.ts
+++ b/src/server/utils/oldItemsMapping.ts
@@ -93,21 +93,32 @@ export function getOldItemImageCandidates(productName: string): string[] {
   return candidates.filter((candidate) => AVAILABLE_OLD_ITEMS.has(candidate));
 }
 
+// Pre-built lowercase index for case-insensitive lookups
+const LOWER_TO_ORIGINAL = new Map<string, string>(
+  [...AVAILABLE_OLD_ITEMS].map((f) => [f.toLowerCase(), f]),
+);
+
 /**
- * Get the local image path for a product from Old Items
- * STRICTLY prefers names ending in "-1.png" as per requirement
+ * Get the local image path for a product from Old Items.
+ * Tries exact case first, then falls back to case-insensitive match so that
+ * template-renamed products (e.g. "Turkish Coffee" vs "turkish coffee") still
+ * resolve correctly after the variant deduplication renames.
  */
 export function getOldItemImage(productName: string): string | null {
   if (!productName) return null;
 
-  // Clean the name slightly if needed (trim)
   const cleanName = productName.trim();
-
-  // STRICT requirement: Try exact name + "-1.png"
   const candidate = `${cleanName}-1.png`;
 
+  // Exact match (fast path)
   if (AVAILABLE_OLD_ITEMS.has(candidate)) {
     return `/Old Items/${candidate}`;
+  }
+
+  // Case-insensitive fallback
+  const original = LOWER_TO_ORIGINAL.get(candidate.toLowerCase());
+  if (original) {
+    return `/Old Items/${original}`;
   }
 
   return null;

--- a/src/server/utils/syncProducts.ts
+++ b/src/server/utils/syncProducts.ts
@@ -76,9 +76,12 @@ function normalizeProduct(
   const template =
     templateId && templateImages ? templateImages.get(templateId) : null;
 
-  // Product availability: active and sale_ok
-  // Note: available_in_pos is not used here because products can be available for both website and POS
-  const available = rec.active !== false && rec.sale_ok !== false;
+  // A product is available on the website if it is active AND either:
+  // - sale_ok (explicitly marked for sale/website), OR
+  // - available_in_pos (sold at the counter — show on website menu even if sale_ok not set)
+  const available =
+    rec.active !== false &&
+    (rec.sale_ok !== false || rec.available_in_pos === true);
 
   const attributes =
     templateId && attributesByTemplate


### PR DESCRIPTION
## Summary

- **Sync EXCLUDED_CATEGORIES** in `categories/route.ts` — was missing 6 entries (`other`, `Uncategorized`, `Miscellaneous`, `Internal`, `Supplies`, `POS Only`) that `products/route.ts` already had. Ghost categories could appear in the nav without matching products.
- **Move category filtering to service layer** (`product.service.ts`) — `filterWebsiteProducts` now blocks excluded categories and POS-only name patterns for all consumers (deals, recommendations, proxy), not just the products API route.
- **Fix `available_in_pos` availability flag** in `normalizeProduct` — products only in POS (not `sale_ok`) were correctly synced but marked unavailable. Now: `available = active && (sale_ok || available_in_pos)`.
- **Case-insensitive image lookup** in `getOldItemImage` — after template rename dedup, product names like `"Americano"` failed to match `"americano-1.png"`. Added pre-built lowercase Map for O(1) fallback.

## Test plan

- [ ] Force sync via admin endpoint and check logs for `[SYNC] Template ... has N variants` output
- [ ] Verify `/en/menu` shows no duplicate products
- [ ] Verify POS-only categories (`other`, `Uncategorized`, etc.) are absent from nav
- [ ] Verify products that are `available_in_pos=true` but `sale_ok=false` render as available (not sold out)
- [ ] Check deals and recommendations pages don't expose excluded-category products
- [ ] Verify `americano` image resolves on product card (`/Old Items/americano-1.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)