### PR TITLE
Allow head barista override counts, add variance alerts and UI badges

### DIFF
--- a/src/app/[locale]/admin/inventory/history/page.tsx
+++ b/src/app/[locale]/admin/inventory/history/page.tsx
@@ -15,6 +15,15 @@ interface CountEntry {
   status: string;
   notes: string | null;
   shortageNotes: string | null;
+  varianceNotes: string | null;
+  hasVarianceAlert: boolean;
+  correctionOfId: string | null;
+  correctionOf?: {
+    id: string;
+    countedBy: { name: string | null; email: string };
+    createdAt: string;
+    submittedAt: string | null;
+  } | null;
   countedBy: { name: string | null; email: string };
   entries: Array<{ itemId: string; totalQuantity: number }>;
   submittedAt: string | null;
@@ -433,6 +442,16 @@ export default function HistoryPage() {
                         <span className="text-xs font-cabin text-elite-black/60">
                           {c.countedBy.name || c.countedBy.email}
                         </span>
+                        {c.correctionOfId && (
+                          <>
+                            <span className="text-xs font-cabin text-elite-black/50">
+                              ·
+                            </span>
+                            <span className="text-xs font-cabin text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full">
+                              {t("overrideBadge")}
+                            </span>
+                          </>
+                        )}
                       </div>
                       <span
                         className={cn(
@@ -455,6 +474,20 @@ export default function HistoryPage() {
                     {c.shortageNotes && (
                       <p className="mt-2 text-xs font-cabin text-amber-700 bg-amber-50 rounded-xl px-3 py-2">
                         {c.shortageNotes}
+                      </p>
+                    )}
+                    {c.correctionOf && (
+                      <p className="mt-2 text-xs font-cabin text-purple-700 bg-purple-50 rounded-xl px-3 py-2">
+                        {t("overrideOf", {
+                          user:
+                            c.correctionOf.countedBy.name ||
+                            c.correctionOf.countedBy.email,
+                        })}
+                      </p>
+                    )}
+                    {c.hasVarianceAlert && c.varianceNotes && (
+                      <p className="mt-2 text-xs font-cabin text-red-700 bg-red-50 rounded-xl px-3 py-2">
+                        {c.varianceNotes}
                       </p>
                     )}
                   </div>

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -58,6 +58,16 @@ export async function GET(req: NextRequest) {
         shortageNotes: true,
         wasteNotes: true,
         hasVarianceAlert: true,
+        varianceNotes: true,
+        correctionOfId: true,
+        correctionOf: {
+          select: {
+            id: true,
+            countedBy: { select: { name: true, email: true } },
+            createdAt: true,
+            submittedAt: true,
+          },
+        },
         countedBy: { select: { name: true, email: true } },
         entries: {
           select: {
@@ -123,6 +133,7 @@ export async function POST(req: NextRequest) {
       wasteNotes,
       submit,
     } = parsed.data;
+    const canOverrideCounts = user.role === "head_barista";
     const today = new Date(new Date().toISOString().split("T")[0]);
     const itemPackSizes = new Map(
       (
@@ -143,13 +154,49 @@ export async function POST(req: NextRequest) {
       };
     });
 
+    const existingSubmitted = await prisma.inventoryCount.findFirst({
+      where: {
+        date: today,
+        shiftConfirmed,
+        location,
+        status: { not: "draft" },
+      },
+      orderBy: { submittedAt: "desc" },
+      select: { id: true, countedById: true },
+    });
+
+    const shouldOverride =
+      submit &&
+      !!existingSubmitted &&
+      canOverrideCounts;
+
+    if (existingSubmitted && !shouldOverride) {
+      return NextResponse.json(
+        { success: false, error: "Count already submitted for this shift" },
+        { status: 409 },
+      );
+    }
+
+    const effectiveCountType = shouldOverride ? "correction" : "regular";
+
+    if (countType !== "regular" && !shouldOverride) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Only regular counts are allowed. Head barista can submit an overwrite correction.",
+        },
+        { status: 400 },
+      );
+    }
+
     const existingDraft = await prisma.inventoryCount.findFirst({
       where: {
         date: today,
         shiftConfirmed,
         location,
         countedById: user.id,
-        countType,
+        countType: "regular",
         status: "draft",
       },
     });
@@ -165,6 +212,8 @@ export async function POST(req: NextRequest) {
           notes,
           shortageNotes,
           wasteNotes,
+          countType: shouldOverride ? "correction" : "regular",
+          correctionOfId: shouldOverride ? existingSubmitted?.id : null,
           status: submit ? "submitted" : "draft",
           submittedAt: submit ? new Date() : null,
           entries: {
@@ -178,25 +227,13 @@ export async function POST(req: NextRequest) {
         await reconcileSubmittedInventoryCount(updated.id, user.id);
       }
 
-      return NextResponse.json({ success: true, data: updated, updated: true });
-    }
-
-    const existingSubmitted = await prisma.inventoryCount.findFirst({
-      where: {
-        date: today,
-        shiftConfirmed,
-        location,
-        countedById: user.id,
-        countType,
-        status: { not: "draft" },
-      },
-    });
-
-    if (existingSubmitted) {
-      return NextResponse.json(
-        { success: false, error: "Count already submitted for this shift" },
-        { status: 409 },
-      );
+      return NextResponse.json({
+        success: true,
+        data: updated,
+        updated: true,
+        overwrite: shouldOverride,
+        overwrittenCountId: shouldOverride ? existingSubmitted?.id : null,
+      });
     }
 
     const count = await prisma.inventoryCount.create({
@@ -205,10 +242,11 @@ export async function POST(req: NextRequest) {
         shiftSuggested: suggestShift(),
         shiftConfirmed,
         location,
-        countType,
+        countType: effectiveCountType,
         countedById: user.id,
         status: submit ? "submitted" : "draft",
         submittedAt: submit ? new Date() : null,
+        correctionOfId: shouldOverride ? existingSubmitted?.id : null,
         notes,
         shortageNotes,
         wasteNotes,
@@ -223,7 +261,15 @@ export async function POST(req: NextRequest) {
       await reconcileSubmittedInventoryCount(count.id, user.id);
     }
 
-    return NextResponse.json({ success: true, data: count }, { status: 201 });
+    return NextResponse.json(
+      {
+        success: true,
+        data: count,
+        overwrite: shouldOverride,
+        overwrittenCountId: shouldOverride ? existingSubmitted?.id : null,
+      },
+      { status: 201 },
+    );
   } catch (error) {
     if (error instanceof Error && error.message.includes("Authentication")) {
       return NextResponse.json(

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -2163,7 +2163,9 @@
         "submitted": "مسلّم",
         "reviewed": "تم المراجعة",
         "flagged": "محتاج متابعة"
-      }
+      },
+      "overrideBadge": "تعديل",
+      "overrideOf": "تعديل على جرد سابق بواسطة {user}"
     },
     "items": {
       "title": "كتالوج الأصناف",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2163,7 +2163,9 @@
         "submitted": "Submitted",
         "reviewed": "Reviewed",
         "flagged": "Flagged"
-      }
+      },
+      "overrideBadge": "Override",
+      "overrideOf": "Overwrote previous count by {user}"
     },
     "items": {
       "title": "Item Catalog",

--- a/src/server/services/inventoryReconciliation.ts
+++ b/src/server/services/inventoryReconciliation.ts
@@ -47,20 +47,44 @@ export async function reconcileSubmittedInventoryCount(
     })
     .filter((entry) => entry.delta !== 0);
 
-  if (movements.length === 0) return { created: 0, skipped: false };
+  if (movements.length === 0) {
+    await prisma.inventoryCount.update({
+      where: { id: count.id },
+      data: {
+        hasVarianceAlert: false,
+        varianceNotes: null,
+      },
+    });
+    return { created: 0, skipped: false };
+  }
 
-  await prisma.stockMovement.createMany({
-    data: movements.map((movement) => ({
-      itemId: movement.itemId,
-      location: count.location,
-      type: "count_reconciliation",
-      quantity: movement.delta,
-      referenceType: "inventory_count",
-      referenceId: count.id,
-      note: `Reconciled ${count.location} stock to submitted count`,
-      recordedById,
-    })),
-  });
+  const totalVariance = movements.reduce(
+    (sum, movement) => sum + Math.abs(movement.delta),
+    0,
+  );
+  const netVariance = movements.reduce((sum, movement) => sum + movement.delta, 0);
+
+  await prisma.$transaction([
+    prisma.stockMovement.createMany({
+      data: movements.map((movement) => ({
+        itemId: movement.itemId,
+        location: count.location,
+        type: "count_reconciliation",
+        quantity: movement.delta,
+        referenceType: "inventory_count",
+        referenceId: count.id,
+        note: `Reconciled ${count.location} stock to submitted count`,
+        recordedById,
+      })),
+    }),
+    prisma.inventoryCount.update({
+      where: { id: count.id },
+      data: {
+        hasVarianceAlert: true,
+        varianceNotes: `System variance detected (${movements.length} items, total change ${totalVariance.toFixed(2)}, net ${netVariance.toFixed(2)}). Verify all withdrawals were logged via transfer page.`,
+      },
+    }),
+  ]);
 
   return { created: movements.length, skipped: false };
 }

--- a/tests/integration/api/inventoryRoute.test.ts
+++ b/tests/integration/api/inventoryRoute.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { prismaMock } from "../../setup/prisma";
+import { POST } from "@/app/api/admin/inventory/route";
+
+const requireRoleMock = vi.fn();
+const reconcileMock = vi.fn();
+
+vi.mock("@/server/auth/session", () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock("@/server/services/inventoryReconciliation", () => ({
+  reconcileSubmittedInventoryCount: reconcileMock,
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/admin/inventory", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const basePayload = {
+  location: "bar",
+  shiftConfirmed: "morning",
+  countType: "regular",
+  submit: true,
+  entries: [
+    {
+      itemId: "00000000-0000-0000-0000-000000000001",
+      quantity: 5,
+      packsCount: 0,
+      looseSingles: 0,
+    },
+  ],
+};
+
+describe("admin inventory POST flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.inventoryItem.findMany.mockResolvedValue([
+      { id: "00000000-0000-0000-0000-000000000001", packSize: 1 },
+    ] as never);
+  });
+
+  it("blocks non-head-barista from submitting once a shift count is already submitted", async () => {
+    requireRoleMock.mockResolvedValue({ id: "user-1", role: "barista" });
+    prismaMock.inventoryCount.findFirst
+      .mockResolvedValueOnce({ id: "submitted-1", countedById: "other-user" } as never)
+      .mockResolvedValueOnce(null as never);
+
+    const response = await POST(makeRequest(basePayload));
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload.success).toBe(false);
+    expect(prismaMock.inventoryCount.create).not.toHaveBeenCalled();
+  });
+
+  it("allows head barista to overwrite with correction count", async () => {
+    requireRoleMock.mockResolvedValue({ id: "head-1", role: "head_barista" });
+    prismaMock.inventoryCount.findFirst
+      .mockResolvedValueOnce({ id: "submitted-1", countedById: "barista-1" } as never)
+      .mockResolvedValueOnce(null as never);
+    prismaMock.inventoryCount.create.mockResolvedValue({
+      id: "count-new",
+      entries: [],
+    } as never);
+    reconcileMock.mockResolvedValue({ created: 1, skipped: false });
+
+    const response = await POST(makeRequest(basePayload));
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(payload.overwrite).toBe(true);
+    expect(payload.overwrittenCountId).toBe("submitted-1");
+    expect(prismaMock.inventoryCount.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          countType: "correction",
+          correctionOfId: "submitted-1",
+        }),
+      }),
+    );
+  });
+
+  it("promotes existing draft into correction when head barista submits override", async () => {
+    requireRoleMock.mockResolvedValue({ id: "head-1", role: "head_barista" });
+    prismaMock.inventoryCount.findFirst
+      .mockResolvedValueOnce({ id: "submitted-1", countedById: "barista-1" } as never)
+      .mockResolvedValueOnce({ id: "draft-1" } as never);
+    prismaMock.inventoryCount.update.mockResolvedValue({
+      id: "draft-1",
+      entries: [],
+    } as never);
+    reconcileMock.mockResolvedValue({ created: 1, skipped: false });
+
+    const response = await POST(makeRequest(basePayload));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.updated).toBe(true);
+    expect(payload.overwrite).toBe(true);
+    expect(prismaMock.inventoryCount.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          countType: "correction",
+          correctionOfId: "submitted-1",
+          status: "submitted",
+        }),
+      }),
+    );
+  });
+
+  it("rejects non-regular count types unless they are valid overwrite submissions", async () => {
+    requireRoleMock.mockResolvedValue({ id: "user-2", role: "barista" });
+    prismaMock.inventoryCount.findFirst
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(null as never);
+
+    const response = await POST(
+      makeRequest({
+        ...basePayload,
+        countType: "correction",
+        submit: false,
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.success).toBe(false);
+    expect(prismaMock.inventoryCount.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/services/inventoryReconciliation.test.ts
+++ b/tests/integration/services/inventoryReconciliation.test.ts
@@ -23,6 +23,13 @@ describe("inventory count reconciliation", () => {
       { itemId: "cups", _sum: { quantity: 8 } },
     ] as never);
     prismaMock.stockMovement.createMany.mockResolvedValue({ count: 2 } as never);
+    prismaMock.inventoryCount.update.mockResolvedValue({ id: "count-1" } as never);
+    prismaMock.$transaction.mockImplementation(async (actions) => {
+      if (Array.isArray(actions)) {
+        return Promise.all(actions as Array<Promise<unknown>>) as never;
+      }
+      return actions(prismaMock) as never;
+    });
 
     const result = await reconcileSubmittedInventoryCount("count-1", "user-1");
 
@@ -43,6 +50,35 @@ describe("inventory count reconciliation", () => {
         }),
       ]),
     });
+    expect(prismaMock.inventoryCount.update).toHaveBeenCalledWith({
+      where: { id: "count-1" },
+      data: expect.objectContaining({
+        hasVarianceAlert: true,
+      }),
+    });
+  });
+
+  it("clears variance metadata when no movement is required", async () => {
+    prismaMock.stockMovement.findFirst.mockResolvedValue(null);
+    prismaMock.inventoryCount.findUnique.mockResolvedValue({
+      id: "count-2",
+      location: "storage",
+      status: "submitted",
+      entries: [{ itemId: "beans", totalQuantity: 4 }],
+    } as never);
+    prismaMock.stockMovement.groupBy.mockResolvedValue([
+      { itemId: "beans", _sum: { quantity: 4 } },
+    ] as never);
+    prismaMock.inventoryCount.update.mockResolvedValue({ id: "count-2" } as never);
+
+    const result = await reconcileSubmittedInventoryCount("count-2", "user-1");
+
+    expect(result).toEqual({ created: 0, skipped: false });
+    expect(prismaMock.stockMovement.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.inventoryCount.update).toHaveBeenCalledWith({
+      where: { id: "count-2" },
+      data: { hasVarianceAlert: false, varianceNotes: null },
+    });
   });
 
   it("is idempotent when reconciliation movements already exist", async () => {
@@ -54,4 +90,3 @@ describe("inventory count reconciliation", () => {
     expect(prismaMock.stockMovement.createMany).not.toHaveBeenCalled();
   });
 });
-


### PR DESCRIPTION
### Motivation
- Prevent duplicate submitted counts while allowing a privileged user to submit an intentional overwrite/correction and surface that fact in the UI. 
- Record and surface reconciliation variance metadata so discrepancies are visible and actionable. 
- Provide localized labels for overrides and variance notes in the history UI.

### Description
- API: expanded `GET` return to include `hasVarianceAlert`, `varianceNotes`, `correctionOfId`, and `correctionOf` relation, and updated `POST` logic to detect `shouldOverride` when `user.role === "head_barista"`, set `countType` to `correction`, set `correctionOfId`, and return `overwrite`/`overwrittenCountId` in responses. 
- Draft promotion and submit flow updated so existing drafts are updated into a correction when an override is performed, and non-regular `countType` submissions are rejected unless they are valid head-barista overrides. 
- Reconciliation: `reconcileSubmittedInventoryCount` now runs stock adjustment creations in a transaction and updates the inventory count with `hasVarianceAlert` and a generated `varianceNotes` summary (and clears those fields when no adjustments are needed). 
- Frontend: history page (`page.tsx`) renders an override badge, an "overrode" note showing the original submitter (`correctionOf`), and displays `varianceNotes` as an alert when `hasVarianceAlert` is set. 
- i18n: added `overrideBadge` and `overrideOf` keys to `en.json` and `ar.json`.
- Tests: added `tests/integration/api/inventoryRoute.test.ts` and extended `tests/integration/services/inventoryReconciliation.test.ts` to cover override behavior and variance metadata handling. 

### Testing
- Ran Vitest integration tests for the inventory API and reconciliation service (`tests/integration/api/inventoryRoute.test.ts` and `tests/integration/services/inventoryReconciliation.test.ts`).
- All added and updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef2087504c83269a13ace2ebf69221)