### PR TITLE
feat: persist inventory count overwrite history and surface in admin UI

### DIFF
--- a/prisma/migrations/20260427091500_add_inventory_count_overwrite_log/migration.sql
+++ b/prisma/migrations/20260427091500_add_inventory_count_overwrite_log/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "InventoryCountOverwriteLog" (
+    "id" TEXT NOT NULL,
+    "countId" TEXT NOT NULL,
+    "overwrittenById" TEXT NOT NULL,
+    "previousSnapshot" JSONB NOT NULL,
+    "newSnapshot" JSONB NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "InventoryCountOverwriteLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InventoryCountOverwriteLog_countId_createdAt_idx" ON "InventoryCountOverwriteLog"("countId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "InventoryCountOverwriteLog_overwrittenById_createdAt_idx" ON "InventoryCountOverwriteLog"("overwrittenById", "createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "InventoryCountOverwriteLog" ADD CONSTRAINT "InventoryCountOverwriteLog_countId_fkey" FOREIGN KEY ("countId") REFERENCES "InventoryCount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InventoryCountOverwriteLog" ADD CONSTRAINT "InventoryCountOverwriteLog_overwrittenById_fkey" FOREIGN KEY ("overwrittenById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   shiftSessions    ShiftSession[]   @relation("ShiftSessions")
   stockMovements   StockMovement[]  @relation("StockMovements")
   inventoryCounts  InventoryCount[] @relation("InventoryCounts")
+  inventoryCountOverwrites InventoryCountOverwriteLog[] @relation("InventoryCountOverwrites")
   stockTransfers   StockTransfer[]  @relation("StockTransfers")
   purchases        Purchase[]       @relation("Purchases")
   wasteEntries     WasteEntry[]     @relation("WasteEntries")
@@ -882,6 +883,7 @@ model InventoryCount {
   varianceNotes    String?
 
   entries InventoryCountEntry[]
+  overwriteLogs InventoryCountOverwriteLog[]
 
   correctionOfId String?
   correctionOf   InventoryCount?  @relation("Corrections", fields: [correctionOfId], references: [id])
@@ -901,6 +903,24 @@ model InventoryCount {
   @@index([date, location])
   @@index([countedById])
   @@index([status])
+}
+
+model InventoryCountOverwriteLog {
+  id String @id @default(uuid())
+
+  countId String
+  count   InventoryCount @relation(fields: [countId], references: [id], onDelete: Cascade)
+
+  overwrittenById String
+  overwrittenBy   User @relation("InventoryCountOverwrites", fields: [overwrittenById], references: [id])
+
+  previousSnapshot Json
+  newSnapshot Json
+  reason String?
+  createdAt DateTime @default(now())
+
+  @@index([countId, createdAt(sort: Desc)])
+  @@index([overwrittenById, createdAt(sort: Desc)])
 }
 
 model InventoryCountEntry {

--- a/src/app/[locale]/admin/inventory/history/page.tsx
+++ b/src/app/[locale]/admin/inventory/history/page.tsx
@@ -19,6 +19,12 @@ interface CountEntry {
   entries: Array<{ itemId: string; totalQuantity: number }>;
   submittedAt: string | null;
   createdAt: string;
+  overwriteLogs?: Array<{
+    id: string;
+    reason: string | null;
+    createdAt: string;
+    overwrittenBy: { name: string | null; email: string };
+  }>;
 }
 
 interface TransferEntry {
@@ -445,9 +451,16 @@ export default function HistoryPage() {
                       </span>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-xs font-cabin text-elite-black/50">
-                        {t("itemCount", { count: c.entries.length })}
-                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-cabin text-elite-black/50">
+                          {t("itemCount", { count: c.entries.length })}
+                        </span>
+                        {(c.overwriteLogs?.length || 0) > 0 && (
+                          <span className="text-[11px] font-cabin px-1.5 py-0.5 rounded-full bg-amber-50 text-amber-700">
+                            ↺ {c.overwriteLogs?.length}
+                          </span>
+                        )}
+                      </div>
                       <span className="text-xs font-cabin text-elite-black/40">
                         {fmtTime(c.createdAt, locale)}
                       </span>

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -71,6 +71,16 @@ export async function GET(req: NextRequest) {
         },
         submittedAt: true,
         createdAt: true,
+        overwriteLogs: {
+          orderBy: { createdAt: "desc" },
+          take: 5,
+          select: {
+            id: true,
+            reason: true,
+            createdAt: true,
+            overwrittenBy: { select: { name: true, email: true } },
+          },
+        },
       },
       orderBy: { createdAt: "desc" },
     });
@@ -155,6 +165,17 @@ export async function POST(req: NextRequest) {
     });
 
     if (existingDraft) {
+      const previousEntries = await prisma.inventoryCountEntry.findMany({
+        where: { countId: existingDraft.id },
+        select: {
+          itemId: true,
+          packsCount: true,
+          looseSingles: true,
+          quantity: true,
+          totalQuantity: true,
+        },
+      });
+
       await prisma.inventoryCountEntry.deleteMany({
         where: { countId: existingDraft.id },
       });
@@ -177,6 +198,32 @@ export async function POST(req: NextRequest) {
       if (submit) {
         await reconcileSubmittedInventoryCount(updated.id, user.id);
       }
+
+      await prisma.inventoryCountOverwriteLog.create({
+        data: {
+          countId: existingDraft.id,
+          overwrittenById: user.id,
+          reason:
+            notes?.trim() ||
+            shortageNotes?.trim() ||
+            wasteNotes?.trim() ||
+            null,
+          previousSnapshot: {
+            notes: existingDraft.notes,
+            shortageNotes: existingDraft.shortageNotes,
+            wasteNotes: existingDraft.wasteNotes,
+            entries: previousEntries,
+            status: existingDraft.status,
+          },
+          newSnapshot: {
+            notes,
+            shortageNotes,
+            wasteNotes,
+            entries: entryCreates,
+            status: submit ? "submitted" : "draft",
+          },
+        },
+      });
 
       return NextResponse.json({ success: true, data: updated, updated: true });
     }


### PR DESCRIPTION
### Motivation
- Preserve an audit trail when draft inventory counts are overwritten so supervisors can trace who changed a count, when, and what changed. 
- Surface overwrite information in the admin history UI so reviewers can quickly spot edited counts.

### Description
- Add a new `InventoryCountOverwriteLog` Prisma model, wire relations from `User` and `InventoryCount`, and include a SQL migration to create the table and indexes. 
- Include a recent `overwriteLogs` selection in `GET /api/admin/inventory` responses so history pages can show recent overwrites per count. 
- When an existing draft inventory count is updated via `POST /api/admin/inventory`, snapshot the previous entries/notes/status and the new payload into `InventoryCountOverwriteLog` with `overwrittenById` and an optional `reason`. 
- Update the admin inventory history UI types and add a compact overwrite badge (`↺ N`) next to count cards to indicate the number of recent overwrites.

### Testing
- Ran TypeScript typecheck with `npx tsc --noEmit -p tsconfig.typecheck.json`, which failed in this environment due to missing local `node` type definitions. 
- Ran `npx prisma validate`, which could not complete in this environment because registry access is blocked (npm 403), so the migration/schema validation could not be confirmed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef522f93d883269a27bfa414a2321c)