### PR TITLE
Keep catalog available during sync

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -37,25 +37,29 @@ export async function GET(_request: NextRequest) {
   try {
     // Add in-memory cache layer on top of Redis (15 minutes TTL)
     // Categories change infrequently, so longer cache is appropriate
-    const cachedResult = await apiCache.get(
-      CacheKeys.categories.all(),
-      async () => {
-        const { categories: allCategories, lastUpdate } =
-          await getCatalogSafe();
-        return { allCategories, lastUpdate };
-      },
-      900, // 15 minutes cache
-    );
+    let cachedResult: {
+      allCategories: Category[];
+      lastUpdate: string | null;
+    };
 
-    let { allCategories, lastUpdate } = cachedResult;
-
-    // getCatalogSafe serves the active catalog snapshot during background syncs.
-    // If Redis/Odoo are both unavailable on a true cold start, return an empty list
-    // instead of exposing a synchronization outage to customers.
-    if (!allCategories) {
-      allCategories = [];
-      lastUpdate = null;
+    try {
+      cachedResult = await apiCache.get(
+        CacheKeys.categories.all(),
+        async () => {
+          const { categories: allCategories, lastUpdate } =
+            await getCatalogSafe();
+          return { allCategories, lastUpdate };
+        },
+        900, // 15 minutes cache
+      );
+    } catch (err) {
+      // True cold start / upstream outage: keep the category endpoint available
+      // instead of showing a customer-facing sync/maintenance error.
+      console.error("[CATEGORIES] Falling back to empty category list:", err);
+      cachedResult = { allCategories: [], lastUpdate: null };
     }
+
+    const { allCategories, lastUpdate } = cachedResult;
 
     // Filter out excluded categories (case-insensitive)
     const categories = allCategories.filter(

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -5,8 +5,7 @@ import {
   successResponse,
   errorResponse,
 } from "@/server/utils/apiHelpers";
-import { redisGet } from "@/server/cache/redis";
-import { syncProductsFromOdoo } from "@/server/utils/syncProducts";
+import { getCatalogSafe } from "@/server/services/product.service";
 import { apiCache, CacheKeys } from "@/lib/apiCache";
 
 type Category = { id: string; name: string; parentId?: string };
@@ -41,10 +40,8 @@ export async function GET(_request: NextRequest) {
     const cachedResult = await apiCache.get(
       CacheKeys.categories.all(),
       async () => {
-        const [allCategories, lastUpdate] = await Promise.all([
-          redisGet<Category[]>("categories:list"),
-          redisGet<string>("sync:last_update"),
-        ]);
+        const { categories: allCategories, lastUpdate } =
+          await getCatalogSafe();
         return { allCategories, lastUpdate };
       },
       900, // 15 minutes cache
@@ -52,78 +49,12 @@ export async function GET(_request: NextRequest) {
 
     let { allCategories, lastUpdate } = cachedResult;
 
-    // Check if cache is empty - auto-sync if needed
+    // getCatalogSafe serves the active catalog snapshot during background syncs.
+    // If Redis/Odoo are both unavailable on a true cold start, return an empty list
+    // instead of exposing a synchronization outage to customers.
     if (!allCategories) {
-      console.log("[CATEGORIES] Cache empty, triggering auto-sync...");
-      const syncResult = await syncProductsFromOdoo();
-      const fallbackCatalog = syncResult.data?.fallbackCatalog as
-        | { categories?: Category[]; lastUpdate?: string | null }
-        | undefined;
-
-      if (!syncResult.success) {
-        // Check if sync is in progress - wait briefly for it
-        const isLocked = await redisGet("sync:in_progress").catch(() => null);
-        if (isLocked) {
-          console.log("[CATEGORIES] Sync in progress, waiting briefly...");
-          // Wait up to 3 seconds for sync to complete
-          for (let i = 0; i < 6; i++) {
-            await new Promise((resolve) => setTimeout(resolve, 500));
-            const waitCategories = await redisGet<Category[]>(
-              "categories:list",
-            ).catch(() => null);
-            const waitLastUpdate = await redisGet<string>(
-              "sync:last_update",
-            ).catch(() => null);
-            if (waitCategories) {
-              allCategories = waitCategories;
-              lastUpdate = waitLastUpdate;
-              break;
-            }
-          }
-        }
-
-        // If still no data after waiting, return 503
-        if (!allCategories) {
-          if (fallbackCatalog?.categories) {
-            allCategories = fallbackCatalog.categories;
-            lastUpdate = fallbackCatalog.lastUpdate || null;
-          }
-        }
-
-        if (!allCategories) {
-          return jsonResponse(
-            errorResponse(
-              "Category list is being synchronized. Please refresh the page in a moment.",
-            ),
-            503,
-          );
-        }
-      } else {
-        // Sync succeeded, fetch fresh data
-        const freshCategories = await redisGet<Category[]>(
-          "categories:list",
-        ).catch(() => null);
-        const freshLastUpdate = await redisGet<string>(
-          "sync:last_update",
-        ).catch(() => null);
-
-        if (freshCategories) {
-          allCategories = freshCategories;
-          lastUpdate = freshLastUpdate;
-        } else if (fallbackCatalog?.categories) {
-          allCategories = fallbackCatalog.categories;
-          lastUpdate = fallbackCatalog.lastUpdate || null;
-        } else {
-          // Sync said it succeeded but no data - this shouldn't happen, but handle gracefully
-          console.error("[CATEGORIES] Sync succeeded but no categories found");
-          return jsonResponse(
-            errorResponse(
-              "Failed to load categories after sync. Please try again.",
-            ),
-            503,
-          );
-        }
-      }
+      allCategories = [];
+      lastUpdate = null;
     }
 
     // Filter out excluded categories (case-insensitive)

--- a/src/server/services/product.service.ts
+++ b/src/server/services/product.service.ts
@@ -151,7 +151,7 @@ export async function getCatalogSafe(): Promise<{
     if (catalog?.products && catalog?.categories) {
       products = catalog.products;
       categories = catalog.categories;
-      lastUpdate = currentTimestamp || catalog.lastUpdate || null;
+      lastUpdate = currentTimestamp || null;
     } else {
       [products, categories, lastUpdate] = await Promise.all([
         redisGet<Product[]>(CACHE_KEYS.DATA),

--- a/src/server/services/product.service.ts
+++ b/src/server/services/product.service.ts
@@ -21,6 +21,7 @@ export type Product = {
 };
 
 const CACHE_KEYS = {
+  CATALOG: "catalog:current",
   DATA: "products:all",
   TIMESTAMP: "sync:last_update",
   LOCK: "sync:in_progress", // Must match SYNC_LOCK_KEY in syncProducts.ts
@@ -138,11 +139,26 @@ export async function getCatalogSafe(): Promise<{
   let lastUpdate: string | null = null;
 
   try {
-    [products, categories, lastUpdate] = await Promise.all([
-      redisGet<Product[]>(CACHE_KEYS.DATA),
-      redisGet<Category[]>(CACHE_KEYS.CATEGORIES),
+    const [catalog, currentTimestamp] = await Promise.all([
+      redisGet<{
+        products?: Product[];
+        categories?: Category[];
+        lastUpdate?: string | null;
+      }>(CACHE_KEYS.CATALOG),
       redisGet<string>(CACHE_KEYS.TIMESTAMP),
     ]);
+
+    if (catalog?.products && catalog?.categories) {
+      products = catalog.products;
+      categories = catalog.categories;
+      lastUpdate = currentTimestamp || catalog.lastUpdate || null;
+    } else {
+      [products, categories, lastUpdate] = await Promise.all([
+        redisGet<Product[]>(CACHE_KEYS.DATA),
+        redisGet<Category[]>(CACHE_KEYS.CATEGORIES),
+        redisGet<string>(CACHE_KEYS.TIMESTAMP),
+      ]);
+    }
   } catch (err) {
     // Redis might be down - log but continue
     console.error(
@@ -301,12 +317,9 @@ export async function invalidateCatalogCache(): Promise<{
   message: string;
 }> {
   try {
-    // Delete timestamp and catalog payload to prevent stale menu data after webhook invalidation.
-    await Promise.all([
-      redisDel(CACHE_KEYS.TIMESTAMP),
-      redisDel(CACHE_KEYS.DATA),
-      redisDel(CACHE_KEYS.CATEGORIES),
-    ]);
+    // Keep the active catalog payload serving while the next sync builds a fresh snapshot.
+    // Deleting products/categories here caused customer-facing 503 responses while sync was running.
+    await redisDel(CACHE_KEYS.TIMESTAMP);
     // Increment version to bust client-side caches
     const version = Date.now().toString();
     await redisSet(CACHE_KEYS.VERSION, version, HARD_TTL);

--- a/src/server/services/product.service.ts
+++ b/src/server/services/product.service.ts
@@ -153,11 +153,11 @@ export async function getCatalogSafe(): Promise<{
       categories = catalog.categories;
       lastUpdate = currentTimestamp || null;
     } else {
-      [products, categories, lastUpdate] = await Promise.all([
+      [products, categories] = await Promise.all([
         redisGet<Product[]>(CACHE_KEYS.DATA),
         redisGet<Category[]>(CACHE_KEYS.CATEGORIES),
-        redisGet<string>(CACHE_KEYS.TIMESTAMP),
       ]);
+      lastUpdate = currentTimestamp || null;
     }
   } catch (err) {
     // Redis might be down - log but continue

--- a/src/server/utils/syncProducts.ts
+++ b/src/server/utils/syncProducts.ts
@@ -751,19 +751,28 @@ async function performSync(
       );
     }
 
+    // Build the next public catalog snapshot in memory first. Writing this single key
+    // is the customer-facing promotion step: the old snapshot remains readable until
+    // the new one has been completely built.
+    const productSummaries = deduplicatedProducts.map((p: any) => {
+      const { thumbnail, images, ...rest } = p;
+      return {
+        ...rest,
+        // Use thumbnail if available, otherwise fallback to existing images (or empty)
+        images: thumbnail ? [thumbnail] : images || [],
+      };
+    });
+
+    const catalogSnapshot = {
+      products: productSummaries,
+      categories,
+      lastUpdate,
+      etag,
+    };
+
     // Cache with partial failure handling - cache what we can even if some writes fail
     const cacheErrors: string[] = [];
-
-    if (redisAvailable) {
-      try {
-        await redisSet("categories:list", categories, cacheTTL);
-      } catch (err) {
-        cacheErrors.push(
-          `Failed to cache categories: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        console.error("[AUTO-SYNC] Failed to cache categories:", err);
-      }
-    }
+    let catalogSnapshotCached = false;
 
     // Cache products individually to allow partial success
     // Store FULL product details (high-res images) in individual keys
@@ -795,23 +804,23 @@ async function performSync(
 
     if (redisAvailable) {
       try {
-        // Create lightweight summaries for the list view
-        // Use the thumbnail as the main image to reduce payload size (50MB -> <2MB)
-        const productSummaries = deduplicatedProducts.map((p: any) => {
-          const { thumbnail, images, ...rest } = p;
-          return {
-            ...rest,
-            // Use thumbnail if available, otherwise fallback to existing images (or empty)
-            images: thumbnail ? [thumbnail] : images || [],
-          };
-        });
-
         await redisSet("products:all", productSummaries, cacheTTL);
       } catch (err) {
         cacheErrors.push(
           `Failed to cache products:all: ${err instanceof Error ? err.message : String(err)}`,
         );
         console.error("[AUTO-SYNC] Failed to cache products:all:", err);
+      }
+    }
+
+    if (redisAvailable) {
+      try {
+        await redisSet("categories:list", categories, cacheTTL);
+      } catch (err) {
+        cacheErrors.push(
+          `Failed to cache categories: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        console.error("[AUTO-SYNC] Failed to cache categories:", err);
       }
     }
 
@@ -842,6 +851,18 @@ async function performSync(
 
     if (redisAvailable) {
       try {
+        await redisSet("catalog:current", catalogSnapshot, cacheTTL);
+        catalogSnapshotCached = true;
+      } catch (err) {
+        cacheErrors.push(
+          `Failed to promote catalog snapshot: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        console.error("[AUTO-SYNC] Failed to promote catalog snapshot:", err);
+      }
+    }
+
+    if (redisAvailable) {
+      try {
         await redisSet("sync:last_update", lastUpdate, cacheTTL);
       } catch (err) {
         cacheErrors.push(
@@ -864,7 +885,8 @@ async function performSync(
       deduplicatedProducts.length > 0 ||
       (deduplicatedProducts.length === 0 && categories.length > 0);
     const isSuccess = redisAvailable
-      ? cachedCount > 0 ||
+      ? catalogSnapshotCached ||
+        cachedCount > 0 ||
         (deduplicatedProducts.length === 0 && categories.length > 0)
       : directDataAvailable;
 

--- a/tests/integration/api/categoriesAvailability.test.ts
+++ b/tests/integration/api/categoriesAvailability.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { apiCache } from "@/lib/apiCache";
+
+const productServiceMocks = vi.hoisted(() => ({
+  getCatalogSafe: vi.fn(),
+}));
+
+vi.mock("@/server/services/product.service", () => ({
+  getCatalogSafe: productServiceMocks.getCatalogSafe,
+}));
+
+describe("categories API availability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiCache.clear();
+  });
+
+  it("returns an empty successful category list when the safe catalog loader fails on cold start", async () => {
+    const { GET } = await import("@/app/api/categories/route");
+    productServiceMocks.getCatalogSafe.mockRejectedValueOnce(
+      new Error("Failed to sync catalog and no cached data available"),
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/categories"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.data).toEqual({ categories: [], lastUpdate: null });
+  });
+
+  it("filters excluded categories from the safe catalog response", async () => {
+    const { GET } = await import("@/app/api/categories/route");
+    productServiceMocks.getCatalogSafe.mockResolvedValueOnce({
+      products: [],
+      categories: [
+        { id: "coffee", name: "Coffee" },
+        { id: "extras", name: "Extras" },
+      ],
+      lastUpdate: "2026-05-04T10:00:00.000Z",
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/categories"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.data).toEqual({
+      categories: [{ id: "coffee", name: "Coffee" }],
+      lastUpdate: "2026-05-04T10:00:00.000Z",
+    });
+  });
+});

--- a/tests/integration/services/catalogAvailability.test.ts
+++ b/tests/integration/services/catalogAvailability.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redisGet, redisQuit, redisSet } from "@/server/cache/redis";
+
+const syncMocks = vi.hoisted(() => ({
+  syncProductsFromOdoo: vi.fn(),
+}));
+
+const nextServerMocks = vi.hoisted(() => ({
+  after: vi.fn((callback: () => unknown) => callback()),
+}));
+
+vi.mock("next/server", async (importActual) => {
+  const actual = await importActual<typeof import("next/server")>();
+  return {
+    ...actual,
+    after: nextServerMocks.after,
+  };
+});
+
+vi.mock("@/server/utils/syncProducts", () => ({
+  syncProductsFromOdoo: syncMocks.syncProductsFromOdoo,
+}));
+
+const catalogProduct = {
+  id: "p1",
+  name: "Latte",
+  price: 80,
+  categoryId: "c1",
+  category: { id: "c1", name: "Coffee" },
+  available: true,
+};
+
+const catalogCategory = { id: "c1", name: "Coffee" };
+
+async function seedPromotedCatalog(lastUpdate = new Date().toISOString()) {
+  await redisSet("catalog:current", {
+    products: [catalogProduct],
+    categories: [catalogCategory],
+    lastUpdate,
+    etag: "etag-current",
+  });
+}
+
+describe("catalog availability during Odoo sync", () => {
+  beforeEach(async () => {
+    await redisQuit();
+    vi.clearAllMocks();
+    syncMocks.syncProductsFromOdoo.mockResolvedValue({ success: true });
+  });
+
+  it("keeps serving the promoted catalog and refreshes in the background when invalidated", async () => {
+    const { getCatalogSafe, invalidateCatalogCache } =
+      await import("@/server/services/product.service");
+
+    await seedPromotedCatalog("2026-05-04T00:00:00.000Z");
+    await redisSet("products:all", [catalogProduct]);
+    await redisSet("categories:list", [catalogCategory]);
+    await redisSet("sync:last_update", "2026-05-04T00:00:00.000Z");
+
+    await invalidateCatalogCache();
+
+    const catalog = await getCatalogSafe();
+
+    expect(catalog.products).toEqual([catalogProduct]);
+    expect(catalog.categories).toEqual([catalogCategory]);
+    expect(catalog.lastUpdate).toBeNull();
+    expect(syncMocks.syncProductsFromOdoo).toHaveBeenCalledWith({
+      bypassCircuitBreaker: false,
+    });
+    expect(await redisGet("products:all")).toEqual([catalogProduct]);
+    expect(await redisGet("categories:list")).toEqual([catalogCategory]);
+    expect(await redisGet("catalog:current")).toMatchObject({
+      products: [catalogProduct],
+      categories: [catalogCategory],
+    });
+  });
+
+  it("does not refresh when the promoted catalog still has a fresh timestamp", async () => {
+    const { getCatalogSafe } =
+      await import("@/server/services/product.service");
+    const freshTimestamp = new Date().toISOString();
+
+    await seedPromotedCatalog("2026-05-04T00:00:00.000Z");
+    await redisSet("sync:last_update", freshTimestamp);
+
+    const catalog = await getCatalogSafe();
+
+    expect(catalog.products).toEqual([catalogProduct]);
+    expect(catalog.categories).toEqual([catalogCategory]);
+    expect(catalog.lastUpdate).toBe(freshTimestamp);
+    expect(syncMocks.syncProductsFromOdoo).not.toHaveBeenCalled();
+  });
+
+  it("falls back to legacy product and category keys before a promoted snapshot exists", async () => {
+    const { getCatalogSafe } =
+      await import("@/server/services/product.service");
+
+    await redisSet("products:all", [catalogProduct]);
+    await redisSet("categories:list", [catalogCategory]);
+    await redisSet("sync:last_update", new Date().toISOString());
+
+    const catalog = await getCatalogSafe();
+
+    expect(catalog.products).toEqual([catalogProduct]);
+    expect(catalog.categories).toEqual([catalogCategory]);
+    expect(syncMocks.syncProductsFromOdoo).not.toHaveBeenCalled();
+  });
+
+  it("uses direct Odoo fallback data when Redis writes fail during a cold start", async () => {
+    const { getCatalogSafe } =
+      await import("@/server/services/product.service");
+
+    syncMocks.syncProductsFromOdoo.mockResolvedValueOnce({
+      success: true,
+      data: {
+        fallbackCatalog: {
+          products: [catalogProduct],
+          categories: [catalogCategory],
+          lastUpdate: "2026-05-04T01:00:00.000Z",
+        },
+      },
+    });
+
+    const catalog = await getCatalogSafe();
+
+    expect(catalog.products).toEqual([catalogProduct]);
+    expect(catalog.categories).toEqual([catalogCategory]);
+    expect(catalog.lastUpdate).toBe("2026-05-04T01:00:00.000Z");
+  });
+});

--- a/tests/integration/services/catalogAvailability.test.ts
+++ b/tests/integration/services/catalogAvailability.test.ts
@@ -98,12 +98,19 @@ describe("catalog availability during Odoo sync", () => {
     await redisSet("products:all", [catalogProduct]);
     await redisSet("categories:list", [catalogCategory]);
     await redisSet("sync:last_update", new Date().toISOString());
+    vi.mocked(redisGet).mockClear();
 
     const catalog = await getCatalogSafe();
 
     expect(catalog.products).toEqual([catalogProduct]);
     expect(catalog.categories).toEqual([catalogCategory]);
     expect(syncMocks.syncProductsFromOdoo).not.toHaveBeenCalled();
+    expect(vi.mocked(redisGet).mock.calls).toEqual([
+      ["catalog:current"],
+      ["sync:last_update"],
+      ["products:all"],
+      ["categories:list"],
+    ]);
   });
 
   it("uses direct Odoo fallback data when Redis writes fail during a cold start", async () => {


### PR DESCRIPTION
### Motivation

- Prevent customer-facing 503/outage when the product/category sync runs by keeping the previous catalog available until the new snapshot is fully prepared.
- Make category endpoints resilient during background syncs so site visitors continue to see the active catalog while updates are applied.

### Description

- Add a promoted snapshot key `catalog:current` and build a `catalogSnapshot` in memory during `performSync` so the old payload remains readable until the new snapshot is fully prepared and promoted via `catalog:current` (changes in `src/server/utils/syncProducts.ts`).
- Make `getCatalogSafe()` prefer the promoted snapshot (`CACHE_KEYS.CATALOG`) and fall back to legacy Redis keys, and use the recorded `sync:last_update` timestamp when available (changes in `src/server/services/product.service.ts`).
- Update the categories API to use `getCatalogSafe()` instead of triggering/awaiting a sync or returning 503s, returning an empty list on a true cold start to avoid surfacing sync outages to customers (changes in `src/app/api/categories/route.ts`).
- Change `invalidateCatalogCache()` to only clear the freshness timestamp instead of deleting the product/category payloads so the active catalog continues serving while the next sync builds the replacement (changes in `src/server/services/product.service.ts`).

### Testing

- Ran formatting check: `npx prettier --check src/server/services/product.service.ts src/app/api/categories/route.ts src/server/utils/syncProducts.ts` — succeeded.
- Ran `git diff --check` — no whitespace/patch errors found.
- Attempted `npm run lint` which failed locally due to missing type definitions (`TS2688: Cannot find type definition file for 'node'`) in the local environment, so full typecheck could not be completed.
- Attempted `npm test` which could not run because `vitest` was not available in the local environment (`vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f91ce18464832693c2bd719cb2ee87)