### PR TITLE
Fix malformed Odoo domain in product sync (search_read)

### DIFF
--- a/src/server/utils/syncProducts.ts
+++ b/src/server/utils/syncProducts.ts
@@ -402,7 +402,7 @@ async function performSync(
         [productsRaw, categoriesRaw] = await Promise.all([
           client.searchRead<ProductRecord>(
             "product.product",
-            [["|", ["sale_ok", "=", true], ["available_in_pos", "=", true]]],
+            ["|", ["sale_ok", "=", true], ["available_in_pos", "=", true]],
             productFields,
             { limit },
           ),
@@ -417,7 +417,7 @@ async function performSync(
         [productsRaw, categoriesRaw] = await Promise.all([
           client.searchReadPaginated<ProductRecord>(
             "product.product",
-            [["|", ["sale_ok", "=", true], ["available_in_pos", "=", true]]],
+            ["|", ["sale_ok", "=", true], ["available_in_pos", "=", true]],
             productFields,
             batchSize,
           ),


### PR DESCRIPTION
### Motivation
- The product sync was passing a nested domain array (`[["|", ...]]`) to Odoo `search_read` which caused Odoo to treat a list as an operator and crash with `TypeError: unhashable type: 'list'` during sync.

### Description
- Fix the domain passed to `client.searchRead` and `client.searchReadPaginated` in `src/server/utils/syncProducts.ts` by changing the domain from `[["|", ...]]` to the correct form `["|", ["sale_ok","=",true], ["available_in_pos","=",true]]` for both limited and paginated fetch paths.

### Testing
- Confirmed the malformed pattern was removed by searching the repo (no matches for `[["|"`), which succeeded.
- Ran type checking with `npx tsc --noEmit`, which failed due to pre-existing environment/type definition issues unrelated to this change (no other automated test failures introduced by this patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcb2a5ac9c8326859ae9ed0c4fbbb0)